### PR TITLE
fea: download post tags

### DIFF
--- a/boosty/api.py
+++ b/boosty/api.py
@@ -1,4 +1,5 @@
 import asyncio
+from msilib.schema import PublishComponent
 import time
 from pathlib import Path
 from typing import Literal
@@ -296,7 +297,12 @@ async def get_all_posts(creator_name: str, post_pool: PostPool, use_cookie: bool
             posts = resp["data"]
             for post in posts:
                 if post["hasAccess"]:
-                    new_post = Post(_id=post["id"], title=post["title"])
+                    new_post = Post(
+                        _id=post["id"],
+                        title=post["title"],
+                        created_at=post['createdAt'],
+                        updated_at=post['updatedAt'],
+                        publish_time=post['publishTime'])
                     for media in post["data"]:
                         if media["type"] == MediaType.VIDEO.value:
                             for url in media["playerUrls"]:

--- a/boosty/api.py
+++ b/boosty/api.py
@@ -322,6 +322,9 @@ async def get_all_posts(creator_name: str, post_pool: PostPool, use_cookie: bool
                         elif media["type"] == MediaType.TEXT:
                             if media["modificator"] == "":
                                 new_post.add_marshaled_paragraph(media["content"])
+                    for tag in post["tags"]:
+                        new_post.add_tag(tag["id"], tag["title"])
+                        post_pool.add_tag(tag["id"], tag["title"])
                     post_pool.add_post(new_post)
             if extra["isLast"]:
                 is_end = True

--- a/boosty/wrappers/post.py
+++ b/boosty/wrappers/post.py
@@ -10,6 +10,7 @@ class Post:
     title: str
     paragraph: List[str]
     media_pool: MediaPool
+    tags: dict
 
     _text_content_malformed: bool = False
 
@@ -18,6 +19,7 @@ class Post:
         self.title = title
         self.media_pool = MediaPool()
         self.paragraph = []
+        self.tags = {}
 
     @property
     def id(self) -> str:
@@ -47,3 +49,11 @@ class Post:
         if len(self.paragraph):
             result += "\n".join(self.paragraph)
         return result
+
+    def add_tag(self, _id: int, title: str):
+        self.tags[_id] = title
+
+    def get_tags_text(self):
+        #sort tags by title and then by id
+        sorted_tags = sorted(self.tags.items(), key=lambda item:f'{item[1]}{item[0]}')
+        return "\n".join([f'{_id}\t{title}' for _id, title in sorted_tags])

--- a/boosty/wrappers/post.py
+++ b/boosty/wrappers/post.py
@@ -11,15 +11,21 @@ class Post:
     paragraph: List[str]
     media_pool: MediaPool
     tags: dict
+    created_at: int
+    updated_at: int
+    publish_time: int
 
     _text_content_malformed: bool = False
 
-    def __init__(self, _id: str, title: str):
+    def __init__(self, _id: str, title: str, created_at: int, updated_at: int, publish_time: int):
         self._id = _id
         self.title = title
         self.media_pool = MediaPool()
         self.paragraph = []
         self.tags = {}
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.publish_time = publish_time
 
     @property
     def id(self) -> str:
@@ -57,3 +63,9 @@ class Post:
         #sort tags by title and then by id
         sorted_tags = sorted(self.tags.items(), key=lambda item:f'{item[1]}{item[0]}')
         return "\n".join([f'{_id}\t{title}' for _id, title in sorted_tags])
+
+    def get_attributes_text(self):
+        return "\n".join([
+            f'createdAt\t{self.created_at}',
+            f'updatedAt\t{self.updated_at}',
+            f'publishTime\t{self.publish_time}'])

--- a/boosty/wrappers/post_pool.py
+++ b/boosty/wrappers/post_pool.py
@@ -5,9 +5,11 @@ from boosty.wrappers.post import Post
 
 class PostPool:
     __posts: dict
+    tags: dict
 
     def __init__(self):
         self.__posts = {}
+        self.tags = {}
 
     @property
     def posts(self) -> List[Post]:
@@ -18,4 +20,12 @@ class PostPool:
 
     def get_post(self, _id: str) -> Optional[Post]:
         return self.__posts.get(_id)
+
+    def add_tag(self, _id: int, title: str):
+        self.tags[_id] = title
+
+    def get_tags_text(self):
+        #sort tags by title and then by id
+        sorted_tags = sorted(self.tags.items(), key=lambda item:f'{item[1]}{item[0]}')
+        return "\n".join([f'{_id}\t{title}' for _id, title in sorted_tags])
 

--- a/core/launchers.py
+++ b/core/launchers.py
@@ -119,6 +119,7 @@ async def fetch_and_save_posts(creator_name: str, use_cookie: bool):
     create_dir_if_not_exists(posts_path)
     post_pool = PostPool()
     await get_all_posts(creator_name=creator_name, post_pool=post_pool, use_cookie=use_cookie)
+    await create_text_document(path=base_path, content=post_pool.get_tags_text(), name="tags")
     coros = []
     desired_post_id = conf.desired_post_id
     if desired_post_id:
@@ -134,7 +135,8 @@ async def fetch_and_save_posts(creator_name: str, use_cookie: bool):
         create_dir_if_not_exists(photo_path)
         create_dir_if_not_exists(video_path)
         create_dir_if_not_exists(audio_path)
-        await create_text_document(path=post_path, content=post.get_contents_text())
+        await create_text_document(path=post_path, content=post.get_contents_text(), name="contents")
+        await create_text_document(path=post_path, content=post.get_tags_text(), name="tags")
 
         images = post.media_pool.get_images()
         grp_photos = []

--- a/core/launchers.py
+++ b/core/launchers.py
@@ -137,6 +137,7 @@ async def fetch_and_save_posts(creator_name: str, use_cookie: bool):
         create_dir_if_not_exists(audio_path)
         await create_text_document(path=post_path, content=post.get_contents_text(), name="contents")
         await create_text_document(path=post_path, content=post.get_tags_text(), name="tags")
+        await create_text_document(path=post_path, content=post.get_attributes_text(), name="attributes")
 
         images = post.media_pool.get_images()
         grp_photos = []


### PR DESCRIPTION
This patch adds the ability to download post tags. It only works when storage_type: post is set in config.
A tags.txt file containing a list of post tags is created in each post folder, and a tags.txt file containing the full list of tags is created in the root folder.